### PR TITLE
runners: Use ubuntu version as an argument

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,15 @@ jobs:
             latest=auto
             prefix=
             suffix=-${{ matrix.ubuntu_version }}-${{ matrix.arch }}
+          tags: |
+            # Generate old tag names (e.g main-s390x, main-x86_64...) when building focal
+            # branch event
+            type=ref,enable=${{ matrix.ubuntu_version == 'focal' }},suffix=-${{ matrix.arch }},event=branch
+            # pr event
+            type=ref,enable=${{ matrix.ubuntu_version == 'focal' }},prefix=pr-,suffix=-${{ matrix.arch }},event=pr
+            # tags for all pr/branches
+            type=ref,event=branch,enable=true,priority=600
+            type=ref,event=pr,enable=true,prefix=pr-,priority=600          
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,8 @@ jobs:
       id-token: write
     strategy:
       matrix:
+        ubuntu_version: [focal, noble]
+        arch: [s390x, aarch64, x86_64]
         include:
           - arch: s390x
             dockerfile: s390x.Dockerfile
@@ -89,7 +91,7 @@ jobs:
           flavor: |
             latest=auto
             prefix=
-            suffix=-${{ matrix.arch }}
+            suffix=-${{ matrix.ubuntu_version }}-${{ matrix.arch }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -103,6 +105,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platform }}
+          build-args: UBUNTU_VERSION=${{ matrix.ubuntu_version }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 # hadolint ignore=DL3007
-FROM myoung34/github-runner:latest
+ARG UBUNTU_VERSION=focal
+FROM myoung34/github-runner:ubuntu-${UBUNTU_VERSION}
+# Redefining UBUNTU_VERSION without a value inherits the global default
+ARG UBUNTU_VERSION
+
 LABEL maintainer="sunyucong@gmail.com"
 
 RUN apt-get update \
@@ -7,7 +11,7 @@ RUN apt-get update \
   && apt-get install -y g++ libelf-dev \
   && apt-get install -y iproute2 iputils-ping \
   && apt-get install -y cpu-checker qemu-kvm qemu-utils qemu-system-x86 qemu-system-s390x qemu-system-arm qemu-guest-agent ethtool keyutils iptables gawk \
-  && echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal main" > /etc/apt/sources.list.d/llvm.list \
+  && echo "deb https://apt.llvm.org/${UBUNTU_VERSION}/ llvm-toolchain-${UBUNTU_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
   && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
   && apt-get update \
   && apt-get install -y clang lld llvm

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -1,12 +1,12 @@
 # Self-Hosted IBM Z Github Actions Runner.
-
+ARG UBUNTU_VERSION=focal
 # Temporary image: amd64 dependencies.
-FROM amd64/ubuntu:20.04 as ld-prefix
+FROM amd64/ubuntu:${UBUNTU_VERSION} as ld-prefix
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y install ca-certificates libicu66 libssl1.1
 
 # Main image.
-FROM s390x/ubuntu:20.04
+FROM s390x/ubuntu:${UBUNTU_VERSION}
 
 # Packages for libbpf testing that are not installed by .github/actions/setup.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/s390x.Dockerfile
+++ b/s390x.Dockerfile
@@ -2,8 +2,10 @@
 ARG UBUNTU_VERSION=focal
 # Temporary image: amd64 dependencies.
 FROM amd64/ubuntu:${UBUNTU_VERSION} as ld-prefix
+# Redefining UBUNTU_VERSION without a value inherits the global default
+ARG UBUNTU_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get -y install ca-certificates libicu66 libssl1.1
+RUN apt-get update && apt-get -y install ca-certificates && if [ ${UBUNTU_VERSION} = "focal" ]; then apt-get -y install libicu66 libssl1.1; else apt-get -y install libicu74 libssl3t64; fi
 
 # Main image.
 FROM s390x/ubuntu:${UBUNTU_VERSION}


### PR DESCRIPTION
Instead of hardcoding version 20.04, use the argument UBUNTU_VERSION and default to "focal" (e.g 20.04). All depedencies accept both 20.04 and focal as a tag to the same container.